### PR TITLE
Adds authorization to the builder

### DIFF
--- a/DemoApi/Program.cs
+++ b/DemoApi/Program.cs
@@ -54,6 +54,8 @@ builder.Services.AddAuthentication("BasicAuthentication")
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformationService>();
 
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
Hi there,

Thanks for the excellent video and repo.

On .NET 9, I had to add `builder.Services.AddAuthorization();` to not have the compiler complain that:

```
System.InvalidOperationException: Unable to find the required services. 
Please add all the required services by calling 'IServiceCollection.AddAuthorization' in the application startup code.
```

Cheers!